### PR TITLE
Import get_ipython for initialization scripts

### DIFF
--- a/Lab 0/Image Information and Metadata.py
+++ b/Lab 0/Image Information and Metadata.py
@@ -1,3 +1,5 @@
+from IPython import get_ipython
+
 if 'google.colab' in str(get_ipython()):
     from google.colab import userdata
     EE_PROJECT_ID = userdata.get('EE_PROJECT_ID') 

--- a/Lab 0/_init.py
+++ b/Lab 0/_init.py
@@ -1,3 +1,5 @@
+from IPython import get_ipython
+
 if 'google.colab' in str(get_ipython()):
     from google.colab import userdata
     EE_PROJECT_ID = userdata.get('EE_PROJECT_ID') 


### PR DESCRIPTION
## Summary
- import `get_ipython` from IPython in initialization scripts to avoid NameError outside notebooks

## Testing
- `python -m py_compile 'Lab 0/_init.py' 'Lab 0/Image Information and Metadata.py'`


------
https://chatgpt.com/codex/tasks/task_e_68abaf1b06ec832199dd06e77e8c35ed